### PR TITLE
Allow for Abstract Types

### DIFF
--- a/src/functions_estimation.jl
+++ b/src/functions_estimation.jl
@@ -35,8 +35,8 @@ end
 
 
 Base.@kwdef mutable struct GMMFit
-    theta0::Vector         # initial conditions   (vector of size P or K x P matrix for K sets of initial conditions)
-    theta_hat::Vector      # estimated parameters (vector of size P)
+    theta0::AbstractVector         # initial conditions   (vector of size P or K x P matrix for K sets of initial conditions)
+    theta_hat::AbstractVector      # estimated parameters (vector of size P)
     theta_names::Union{Vector{String}, Nothing}
     theta_factors::Union{Vector{Float64}, Nothing} = nothing # nothing or a vector of length P with factors for each parameter. Parameter theta[i] was replaced by theta[i] * theta_factors[i] before optimization
 
@@ -180,9 +180,9 @@ function fit(
 
     # checks # TODO: add more
     @assert isa(mom_fn, Function) "mom_fn must be a function"
-    @assert isa(theta0, Vector) || isa(theta0, Matrix) "theta0 must be a Vector (P) or a Matrix (K x P)"
-    @assert isa(W, Matrix) || isa(W, UniformScaling) "W must be a Matrix or UniformScaling (e.g. I)"
-    @assert isa(weights, Vector) || isnothing(weights) "weights must be a Vector or nothing"
+    @assert isa(theta0, AbstractVector) || isa(theta0, AbstractMatrix) "theta0 must be a Vector (P) or a Matrix (K x P)"
+    @assert isa(W, AbstractMatrix) || isa(W, UniformScaling) "W must be a Matrix or UniformScaling (e.g. I)"
+    @assert isa(weights, AbstractVector) || isnothing(weights) "weights must be a Vector or nothing"
     @assert mode == :onestep || mode == :twostep "mode must be :onestep or :twostep"    
 
     # one-step or two-step GMM
@@ -321,7 +321,7 @@ function fit_onestep(
 
     ### initial conditions
         # number of initial conditions (and always format as matrix, rows=iterations, columns=paramters)
-        isa(theta0, Vector) && (theta0 = Matrix(transpose(theta0)))
+        isa(theta0, AbstractVector) && (theta0 = Matrix(transpose(theta0)))
         nic = size(theta0, 1)
         
         # number of parameters

--- a/src/optimization_backends.jl
+++ b/src/optimization_backends.jl
@@ -113,11 +113,11 @@ end
 ### OPTIM.JL BACKEND
 ####################
 
-function gmm_objective(theta::Vector, data, mom_fn::Function, W, weights; trace=0)
+function gmm_objective(theta::AbstractVector, data, mom_fn::Function, W, weights; trace=0)
 
     t1 = @elapsed m = mom_fn(data, theta)
 
-    @assert isa(m, Matrix) "m(data, theta) must return a Matrix (rows = observations, columns = moments)"
+    @assert isa(m, AbstractMatrix) "m(data, theta) must return a Matrix (rows = observations, columns = moments)"
 
     (trace > 1) && println("Evaluation took ", t1)
     

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -3,10 +3,9 @@
 """
 Creates a random matrix of initial conditions, taking bounds into account
 """
-function random_initial_conditions(theta0::Vector, nic::Int; theta_lower=nothing, theta_upper=nothing)
-
+function random_initial_conditions(theta0::AbstractVector, nic::Int; theta_lower=nothing, theta_upper=nothing)
     n_params = length(theta0)
-    theta0_mat = zeros(nic, n_params)
+    theta0_mat = ones(nic) * theta0'
     isnothing(theta_lower) && (theta_lower = fill(-Inf, n_params))
     isnothing(theta_upper) && (theta_upper = fill( Inf, n_params))
 
@@ -35,6 +34,8 @@ function random_initial_conditions(theta0::Vector, nic::Int; theta_lower=nothing
 
     return theta0_mat
 end
+
+
 
 """
 theta_fix is a vector with the fixed values of the parameters, and missing at the other locations


### PR DESCRIPTION
Hi,

Big fan of the package, thanks for putting this together.

This change swaps some of the type requirements from `Vector` and `Matrix` to `AbstractVector` and `AbstractMatrix` so that packages like [ComponentArrays](https://github.com/jonniedie/ComponentArrays.jl)  (or [StaticArrays](https://github.com/JuliaArrays/StaticArrays.jl)) can be used for the parameter vector.


```jl
using ComponentArrays
using StaticArrays
# ...

function ols_moments_fn(data, theta)
    resids = @. data.mpg - theta[1] - theta[2] * data.acceleration
return hcat(resids, resids .* data.acceleration)
end

function ca_ols_moments_fn(data, theta)
    # n.b. don't have to worry about order of theta vector now
    (; β_1, β_0) = theta
    resids = @. data.mpg - β_0 - β_1 * data.acceleration
return hcat(resids, resids .* data.acceleration)
end

# initial parameter guess
Random.seed!(123)
theta0 = random_initial_conditions([10.0, 0.0], 20);

ca_t0 = ComponentArray(β_0 = 0.0, β_1 = 10.0);
ca_theta0 = random_initial_conditions(ca_t0, 20);

sa_t0 = SVector(0.0, 10.0);

### Most parsimonius usage
myfit = GMMTools.fit(df, ols_moments_fn, theta0)
ca_myfit = GMMTools.fit(df, ca_ols_moments_fn, ca_theta0)
# n.b. only use single initial guess as `random_initial_conditions` won't 
# generate a StaticArray
sa_myfit = GMMTools.fit(df, ols_moments_fn, sa_t0)

myfit.theta_hat

2-element Vector{Float64}:
 4.9697930042582295
 1.1912045293499602

ca_myfit.theta_hat

ComponentVector{Float64}(β_0 = 4.969793004248007, β_1 = 1.1912045293505955)




```